### PR TITLE
add python3, update dependencies, update documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ ARG AWS_CLI_VERSION
 ARG TERRAFORM_VERSION
 ARG DEBIAN_VERSION=bookworm-20231120-slim
 ARG DEBIAN_FRONTEND=noninteractive
+ARG PYTHON_MAJOR_VERSION=3.11
 
 # Download Terraform binary
 FROM debian:${DEBIAN_VERSION} as terraform
@@ -11,7 +12,7 @@ ARG TERRAFORM_VERSION
 RUN apt-get update
 # RUN apt-get install --no-install-recommends -y libcurl4=7.74.0-1.3+deb11u7
 RUN apt-get install --no-install-recommends -y ca-certificates=20230311
-RUN apt-get install --no-install-recommends -y curl=7.88.1-10+deb12u4
+RUN apt-get install --no-install-recommends -y curl=7.88.1-10+deb12u5
 RUN apt-get install --no-install-recommends -y gnupg=2.2.40-1.1
 RUN apt-get install --no-install-recommends -y unzip=6.0-28
 WORKDIR /workspace
@@ -28,7 +29,7 @@ FROM debian:${DEBIAN_VERSION} as aws-cli
 ARG AWS_CLI_VERSION
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates=20230311
-RUN apt-get install -y --no-install-recommends curl=7.88.1-10+deb12u4
+RUN apt-get install --no-install-recommends -y curl=7.88.1-10+deb12u5
 RUN apt-get install -y --no-install-recommends gnupg=2.2.40-1.1
 RUN apt-get install -y --no-install-recommends unzip=6.0-28
 RUN apt-get install -y --no-install-recommends git=1:2.39.2-1.1
@@ -45,14 +46,17 @@ RUN ./aws/install --install-dir /usr/local/aws-cli --bin-dir /usr/local/bin
 # Build final image
 FROM debian:${DEBIAN_VERSION} as build
 LABEL maintainer="bgauduch@github"
+ARG PYTHON_MAJOR_VERSION
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates=20230311\
     git=1:2.39.2-1.1 \
     jq=1.6-2.1 \
-    openssh-client=1:9.2p1-2+deb12u1 \
+    python3=${PYTHON_MAJOR_VERSION}.2-1+b1 \
+    openssh-client=1:9.2p1-2+deb12u2 \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* \
+  && update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_MAJOR_VERSION} 1
 WORKDIR /workspace
 COPY --from=terraform /workspace/terraform /usr/local/bin/terraform
 COPY --from=aws-cli /usr/local/bin/ /usr/local/bin/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Tools included:
 * [AWS CLI](https://aws.amazon.com/fr/cli/)
 * [Git](https://git-scm.com/) for Terraform remote module usage
 * [jq](https://stedolan.github.io/jq/) to process JSON returned by AWS
+* [Python 3](https://www.python.org/)
 * [OpenSSH Client](https://www.openssh.com/) to handle Terraform module clone over SSH
 * This image uses a non-root user with a UID and GID of 1001 to conform with docker security best practices.
 
@@ -88,6 +89,7 @@ TERRAFORM_VERSION=1.5.2
 ```
 
 ## 🙏 Contributions
+
 Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/terraform-aws-cli/issues) or [a PR](https://github.com/Zenika/terraform-aws-cli/pulls) !
 
 ## 📚 Documentations
@@ -100,6 +102,7 @@ Do not hesitate to contribute by [filling an issue](https://github.com/Zenika/te
 * For Azure: [zenika-open-source/terraform-azure-cli](https://github.com/zenika-open-source/terraform-azure-cli)
 
 ## 📖 License
+
 This project is under the [Apache License 2.0](https://raw.githubusercontent.com/Zenika/terraform-aws-cli/master/LICENSE)
 
 [![with love by zenika](https://img.shields.io/badge/With%20%E2%9D%A4%EF%B8%8F%20by-Zenika-b51432.svg)](https://oss.zenika.com)

--- a/docs/dependencies-upgrades.md
+++ b/docs/dependencies-upgrades.md
@@ -5,11 +5,13 @@
   * check available **AWS CLI** version on the [project release page](https://github.com/aws/aws-cli/tags)
   * check available **Terraform CLI** version (keep all minor versions from 0.11) on the [project release page](https://github.com/hashicorp/terraform/releases)
 * Dockerfile:
-  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye)
+  * check **base image** version [on DockerHub](https://hub.docker.com/_/debian?tab=tags&page=1&name=bookworm)
   * check OS package versions on Debian package repository
-    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bullseye&arch=any&searchon=names&keywords=git)
-    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bullseye&arch=any&searchon=names&keywords=jq)
+    * Available **Git** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=git)
+    * Available **Python** versions on the [Debian packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=python3)
+    * Available **JQ** versions on the [Debian Packages repository](https://packages.debian.org/search?suite=bookworm&arch=any&searchon=names&keywords=jq)
     * same process for all other packages
+  * check **Pip** package versions on [pypi](https://pypi.org/)
 * Dockerfile tests : update version according to changes in Dockerfile in [tests/container-structure-tests.yml.template](tests/container-structure-tests.yml.template)
 * Github actions:
   * check [runner version](https://github.com/actions/virtual-environments#available-environments)

--- a/tests/container-structure-tests.yml.template
+++ b/tests/container-structure-tests.yml.template
@@ -8,6 +8,11 @@ metadataTest:
   workdir: "/workspace"
 
 commandTests:
+  - name: "Check Python version"
+    command: "python"
+    args: ["--version"]
+    expectedOutput: ["Python 3.11.2"]
+
   - name: "Check Git version"
     command: "git"
     args: ["--version"]


### PR DESCRIPTION
My team needs to have Python for part of our CI/CD pipeline that uses this image.

I saw someone else requested adding it back (https://github.com/zenika-open-source/terraform-aws-cli/issues/80), so I put together a PR for it.

While testing I saw that a couple system packages didn't have the old pinned version available in their package repository anymore.

