### PR TITLE
ci(commitlint): require BREAKING CHANGE footers, restate the v9/v10 notes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,14 @@ the squash-merge subject and feeds the release-please changelog. See docs/roadma
 
 Roadmap phase / closes: <!-- e.g. Phase 1 — closes #105 -->
 
+## Breaking change
+
+<!-- Leave empty unless the PR title carries `!`. If it does, end this
+description with a footer line reading `BREAKING CHANGE:` followed by what a
+consumer must change. release-please copies that footer verbatim into the
+release notes and CHANGELOG.md; without it they only repeat the subject
+(conventions C4, enforced by the commitlint job). -->
+
 ## Architecture Decision Record
 
 <!-- A structural change (Dockerfile, workflows, supported_versions.json, release/

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,9 +1,11 @@
 name: commitlint
 
 # Validate Conventional Commits (ADR-0002) with commitlint as the SINGLE engine,
-# on both the PR commits and the PR title (the squash-merge subject that feeds
-# release-please). Only official actions/* + the @commitlint/* packages — no
-# third-party actions (supply-chain hardening; Phase 4/5 orientation).
+# on both the PR commits and the squash-merge message. The latter is the PR
+# title AND description, because that is the commit release-please parses and
+# the only place a `BREAKING CHANGE:` footer can reach it (conventions C4).
+# Only official actions/* + the @commitlint/* packages — no third-party
+# actions (supply-chain hardening; Phase 4/5 orientation).
 
 on:
   pull_request:
@@ -47,7 +49,10 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: npx commitlint --from "$BASE_SHA" --to "$HEAD_SHA" --verbose
 
-      - name: Lint PR title
+      - name: Lint squash-merge message (PR title + description)
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: printf '%s' "$PR_TITLE" | npx commitlint --verbose
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s\n\n%s\n' "$PR_TITLE" "$PR_BODY" \
+            | npx commitlint --config commitlint.squash.config.mjs --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **ci:** publish only the platforms upstream supports ([#164](https://github.com/bgauduch/terraform-aws-cli/issues/164))
+* **ci:** `linux/arm/v7` and `linux/386` are no longer published — remaining platforms are `linux/amd64` and `linux/arm64`. Existing tags keep their manifests. ([#164](https://github.com/bgauduch/terraform-aws-cli/issues/164))
 
 ### Features
 
@@ -16,8 +16,8 @@
 
 ### ⚠ BREAKING CHANGES
 
-* **ci:** one publisher per tag, edge from master and latest from releases ([#163](https://github.com/bgauduch/terraform-aws-cli/issues/163))
-* **versions:** support follows upstream EOL, retire minors below 1.13 ([#158](https://github.com/bgauduch/terraform-aws-cli/issues/158))
+* **ci:** `latest` now moves only on release — use `edge` for the tip of `master`. ([#163](https://github.com/bgauduch/terraform-aws-cli/issues/163))
+* **versions:** Terraform lines below 1.13 are no longer built — supported: 1.13, 1.14, 1.15. Existing tags stay pullable. ([#158](https://github.com/bgauduch/terraform-aws-cli/issues/158))
 
 ### Features
 

--- a/commitlint.squash.config.mjs
+++ b/commitlint.squash.config.mjs
@@ -1,0 +1,44 @@
+import base from "./commitlint.config.mjs";
+
+// Config for the squash-merge message (PR title + description), the commit
+// release-please actually parses. Two departures from the per-commit config:
+// the description is markdown, so the commit line-length limits cannot apply;
+// and a `!` subject is only a marker, so the footer carrying the prose is
+// required here (conventions C4).
+const BREAKING_HEADER = /^[a-zA-Z]+(\([^)]*\))?!:/;
+
+const breakingChangeFooter = {
+  rules: {
+    "breaking-change-footer": ({ header, subject, notes }) => {
+      if (!BREAKING_HEADER.test(header ?? "")) {
+        return [true];
+      }
+
+      const note = (notes ?? []).find((entry) =>
+        /^BREAKING[ -]CHANGE$/.test(entry.title ?? ""),
+      );
+      const text = (note?.text ?? "").trim();
+
+      // A missing footer is indistinguishable from one repeating the subject:
+      // the parser synthesises the note from `!` using the subject, which is
+      // why release-please renders the subject when no footer was written.
+      const stated = text !== "" && text !== (subject ?? "").trim();
+
+      return [
+        stated,
+        "a `!` subject needs a `BREAKING CHANGE: <effect>` footer at the end of the PR description, stating what a consumer must change: release-please copies that footer into the release notes and CHANGELOG.md, and falls back to the subject when it is absent",
+      ];
+    },
+  },
+};
+
+export default {
+  ...base,
+  plugins: [breakingChangeFooter],
+  rules: {
+    ...(base.rules ?? {}),
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0],
+    "breaking-change-footer": [2, "always"],
+  },
+};

--- a/docs/adr/0002-contribution-and-release-workflow.md
+++ b/docs/adr/0002-contribution-and-release-workflow.md
@@ -67,3 +67,13 @@ Tag strategy is decided separately in ADR-0003.
 > (tags pushed by `GITHUB_TOKEN` do not trigger other workflows) and fits the
 > low-friction driver. Mechanism clarification; the decision (release-please,
 > Release-PR trigger) is unchanged.
+>
+> **Amended 2026-08-03** — the `BREAKING CHANGE:` footer this ADR relies on is
+> now required and linted, not merely available: commitlint validates the
+> composed squash-merge message (PR title + description) against
+> `commitlint.squash.config.mjs`, which fails a `!` subject carrying no footer
+> or one that repeats the subject. The obligation is [conventions
+> C4](../conventions.md#commits); v9.0.0 and v10.0.0 shipped before it and
+> announced breaks without stating them. Enforcement of an existing mechanism;
+> the decision (Conventional Commits, squash-merge, release-please) is
+> unchanged.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -37,6 +37,10 @@ Agent-session rules (authorization boundaries, roles) live in
 - **C2 — One commit per logical change.**
 - **C3 — `NEVER` bypass hooks** (no `--no-verify`, no `--no-gpg-sign`) — a
   failing hook is a signal; fix the cause.
+- **C4 — A `!` subject ships with a `BREAKING CHANGE:` footer** stating what a
+  consumer must change, at the end of the PR description. `NEVER` restate the
+  subject: release-please copies the footer into the release notes and the
+  changelog, and falls back to the subject when it is absent.
 
 ## Delivery
 


### PR DESCRIPTION
## Summary

`v9.0.0` and `v10.0.0` both shipped a `⚠ BREAKING CHANGES` section that only
**repeats the commit subject**. A consumer is told a break exists and never told
what to change: v10.0.0 never names `linux/arm/v7` or `linux/386`, v9.0.0 never
says that `latest` stopped following `master`.

The cause is mechanical, not editorial. release-please renders the
`BREAKING CHANGE:` footer body; with only `!` on the subject line there is no
footer, and the conventional-commits parser **synthesises the note from the
subject** — so the subject is what gets printed. ADR-0002 already records that
the squash body carries these footers, but nothing required or checked one: the
commitlint job lints the PR commits and the **bare PR title**, neither of which
contains the description. The footer was structurally unlintable.

Two commits: restate what shipped, then make the omission impossible.

### Restated notes (`CHANGELOG.md`)

One line per break, naming the tags and the migration:

- **v10.0.0** — `linux/arm/v7` and `linux/386` are no longer published; remaining
  platforms are `linux/amd64` and `linux/arm64`; existing tags keep their manifests.
- **v9.0.0** — `latest` now moves only on release, use `edge` for the tip of
  `master`; Terraform lines below 1.13 are no longer built, existing tags stay pullable.

### Enforcement

- **`commitlint.squash.config.mjs`** (new) — extends the per-commit config, adds
  the `breaking-change-footer` rule, and disables `body-max-line-length` /
  `footer-max-line-length`, which cannot apply to a markdown PR description.
- **`commitlint.yml`** — lints the **composed squash-merge message** (title +
  description) instead of the title alone. That message is exactly what
  release-please parses, and the only place a footer can reach it. The
  per-commit lint is unchanged, and the rule is deliberately squash-only.
- **`docs/conventions.md`** — new rule **C4**, the obligation itself. This is the
  `!`-marks-a-break learning graduating from the tracking issue (L4).
- **PR template** — a `## Breaking change` block. Kept as an HTML comment with no
  line-leading token, verified inert: it cannot satisfy the rule by itself.
- **ADR-0002** — dated amendment recording the enforcement.

Roadmap phase / closes: none — hygiene from the v9/v10 release review (#106).

## Breaking change

<!-- Not a breaking change: the rule constrains future PR descriptions only. -->

## Verification

`./scripts/validate.sh --fast` green; `commitlint.yml` parses as YAML. The rule
was exercised locally against `@commitlint/cli` on five messages:

| Case | Expected | Result |
|---|---|---|
| `feat(ci)!:` no footer | fail | fail |
| `feat(ci)!:` + real footer | pass | pass |
| `feat(ci)!:` + footer repeating the subject | fail | fail |
| non-breaking subject, no footer | pass | pass |
| breaking + footer + a >100-char markdown body line | pass | pass |

Plus two negative checks: the per-commit config still accepts a breaking subject
with no footer (rule is squash-only), and the new template block does not
satisfy the rule on its own.

A missing footer and a footer repeating the subject are the **same state** to the
parser, so they share one message rather than pretending to distinguish them.

## Out of scope

- **The published release bodies on GitHub.** `CHANGELOG.md` is fixed here, but
  the two release descriptions must be edited by hand — no tool in the authoring
  session can write a release body (the GitHub MCP surface is read-only on
  releases). release-please only writes a body at creation, so a manual edit is
  safe and will not be reverted. Until then `CHANGELOG.md` and the release pages
  differ.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link:
  `docs/adr/0002-contribution-and-release-workflow.md`)
- [ ] This PR is **not** a structural change — no ADR needed

The change is structural (`.github/workflows/**` + commit configuration). It
**amends** ADR-0002 rather than adding an ADR: the decision it records
(Conventional Commits, squash-merge, release-please) is unchanged, and the footer
it already relied on merely becomes enforced — a clarification under the
amend-vs-supersede rule. The obligation itself is a reversible convention, so its
home is `docs/conventions.md` (C4), not a new ADR.

> **Note for the reviewer.** `adr-check` **passed** on that amendment, which this
> PR originally predicted would fail. Its condition is
> `^docs/adr/[0-9]{4}-.+\.md$` against `git diff --name-only` — it accepts any
> **changed** ADR file, added or modified, while `docs/adr/README.md` describes
> the gate as requiring a *new* `NNNN-*.md`. The pass is the right verdict here,
> since an amendment is the correct response; but the same gate would be
> satisfied by a typo fix in an unrelated ADR. Recorded as a learning in #106,
> not fixed here (out of this PR's scope).

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope