### PR TITLE
fix(docker): refresh the superseded jq and unzip apt pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 RUN apt-get install --no-install-recommends -y ca-certificates=20250419
 RUN apt-get install --no-install-recommends -y curl=8.14.1-2+deb13u4
 RUN apt-get install --no-install-recommends -y gnupg=2.4.7-21+deb13u1
-RUN apt-get install --no-install-recommends -y unzip=6.0-29
+RUN apt-get install --no-install-recommends -y unzip=6.0-29+deb13u1
 WORKDIR /workspace
 # plain --retry does not cover connection resets (curl exit 35), --retry-all-errors does
 RUN curl --silent --show-error --fail --retry 5 --retry-delay 2 --retry-all-errors --remote-name https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
@@ -31,9 +31,9 @@ RUN apt-get update
 RUN apt-get install -y --no-install-recommends ca-certificates=20250419
 RUN apt-get install -y --no-install-recommends curl=8.14.1-2+deb13u4
 RUN apt-get install -y --no-install-recommends gnupg=2.4.7-21+deb13u1
-RUN apt-get install -y --no-install-recommends unzip=6.0-29
+RUN apt-get install -y --no-install-recommends unzip=6.0-29+deb13u1
 RUN apt-get install -y --no-install-recommends git=1:2.47.3-0+deb13u1
-RUN apt-get install -y --no-install-recommends jq=1.7.1-6+deb13u2
+RUN apt-get install -y --no-install-recommends jq=1.7.1-6+deb13u3
 WORKDIR /workspace
 # AWS names bundle arches x86_64/aarch64, not amd64/arm64; arches without an
 # upstream bundle keep x86_64 (unchanged behaviour)
@@ -54,7 +54,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends \
     ca-certificates=20250419 \
     git=1:2.47.3-0+deb13u1 \
-    jq=1.7.1-6+deb13u2 \
+    jq=1.7.1-6+deb13u3 \
     openssh-client=1:10.0p1-7+deb13u4 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

**`master` no longer builds.** Debian published `jq 1.7.1-6+deb13u3` and withdrew `u2` from the trixie index, so the pinned install in the final stage cannot resolve:

```
jq : Depends: libjq1 (= 1.7.1-6+deb13u2) but 1.7.1-6+deb13u3 is to be installed
E: Unable to correct problems, you have held broken packages.
```

`apt` exits 100 and the build dies at `Dockerfile:53`. This is not branch-specific — the `RUN` is identical on `master`, so every image-touching pull request fails on it, and so will the next `edge` push. Found by #167's gate ([run](https://github.com/bgauduch/terraform-aws-cli/actions/runs/32154580041)).

`unzip` moved `6.0-29` → `6.0-29+deb13u1` in the same window. That one is **still installable**, so it broke nothing, but it is superseded and ADR-0010 has pins refreshed when Debian supersedes them — same file, same class, one line each.

This is the drift class ADR-0010 documents and `docs/dependencies-upgrades.md` gives the procedure for. Kept out of #167 per D3: that PR's scope is the gate, not the image.

## Verification

Replayed both install lines against the live trixie index, in the pinned base image (`debian:trixie-slim@sha256:020c0d2…`):

| Line | Result |
|---|---|
| `terraform` / `aws-cli` stages (`ca-certificates`, `curl`, `gnupg`, `unzip`, `git`, `jq`) | resolves |
| `build` stage (`ca-certificates`, `git`, `jq`, `openssh-client`) | resolves |

The strings `tests/container-structure-tests.yml.template` asserts are unchanged, so the template does not move with this bump:

```
git version 2.47.3
jq-1.7
OpenSSH_10.0p2 Debian-7+deb13u4, OpenSSL 3.5.6 7 Apr 2026
```

`./scripts/validate.sh --fast` green. The full build is CI's to prove: this environment's egress proxy terminates TLS and the build containers do not trust its CA, so `--full` cannot complete here.

## Architecture Decision Record

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] This PR is **not** a structural change — no ADR needed

It touches `Dockerfile`, which `adr-check` treats as structural, so the gate will ask for one. Per [`docs/adr/README.md`](https://github.com/bgauduch/terraform-aws-cli/blob/master/docs/adr/README.md) — *"a pure version bump, a typo fix, or a docs tweak does not need an ADR"* — this wants the **`adr-not-needed` label**, which is yours to apply; the policy it follows is already ADR-0010.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed (no policy change — ADR-0010 unchanged)
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared scope

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVj4gmfb1TMj2ZYh4hth3c)_