### PR TITLE
docs(agents): ask maintainer decisions, do not narrate them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,9 @@ One home per fact: reference these, never copy them.
   wait when a fix is ambiguous, architecturally significant, or beyond the PR's
   declared scope.
 - **`NEVER` delete a branch, tag, or remote ref** without explicit approval.
+- **`ALWAYS` put a decision that is the maintainer's through the session's
+  question tool** — a question trailing a message is not a pending decision, it
+  is lost scrollback. Batch the open ones rather than asking one per message.
 - **Net-new work enters through the intake pipeline** (ADR-0014,
   [`docs/work-intake-and-triage.md`](docs/work-intake-and-triage.md)): dedupe
   and get a human `go` before creating an issue or starting delivery. Trivial


### PR DESCRIPTION
## Summary

One session left six decisions that were the maintainer's as questions at the
end of messages rather than asking them. They accumulated unanswered in the
scrollback with no visible state, and the maintainer had to point out that the
session's question tool had been used once, early on, and then quietly dropped.

The behaviour was corrected by request. This PR makes it bind sessions that
have not had the conversation — which is the whole point, and the repository's
own standing lesson: *a rule that lives only in prose is not a rule, it is a
hope.* A rule that lives only in one session's chat is weaker still.

One bullet, added to **Session rules** in `AGENTS.md`:

> **`ALWAYS` put a decision that is the maintainer's through the session's
> question tool** — a question trailing a message is not a pending decision, it
> is lost scrollback. Batch the open ones rather than asking one per message.

## Why there and not in `docs/conventions.md`

The session rules are where the repository's other authorization boundaries
already sit: who merges (never the agent), who approves a ref deletion, who
gives the intake `go`. Those say *who owns a decision*; this one says *how the
decision reaches them*. `docs/conventions.md` binds every contributor including
humans, and a human does not have a question tool.

Both files are imported into every session by `CLAUDE.md`, so either would be
loaded — this is about which home the fact belongs to (conventions L2), not
about reach.

## Architecture Decision Record

- [ ] This PR adds/updates an ADR under `docs/adr/`
- [x] This PR is **not** a structural change — no ADR needed

`AGENTS.md` is outside `adr-check`'s structural paths, and per
[`docs/adr/README.md`](docs/adr/README.md) a reversible convention does not meet
the ADR requirement: no trade-off is being locked in, and the rule is one line
to remove.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

`./scripts/validate.sh --fast` green. Branched from `master`, independent of
#172.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7WnoGWCWkrxL9aw1ejJDt)_