### PR TITLE
docs(intake): give an incident its own lane, and load the checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,3 +10,5 @@ Code settings (adapter layer). Keep instructions in `AGENTS.md`, not here.
 @docs/conventions.md
 
 @docs/adr/README.md
+
+@docs/work-intake-and-triage.md

--- a/docs/adr/0009-agent-agnostic-framework.md
+++ b/docs/adr/0009-agent-agnostic-framework.md
@@ -19,6 +19,12 @@
 > previously invisible to agents. The core/adapter split is unchanged; another
 > tool's adapter would use its own equivalent loading mechanism.
 
+> **Amended 2026-08-22** — `docs/work-intake-and-triage.md` joins the imports
+> above. Two sessions skipped the same intake phase while the checklist was
+> merely linked from `AGENTS.md`, which is the failure the 2026-07-23 amendment
+> already recorded for the conventions. This is an immediate measure, not a
+> criterion: what an agent must hold in context is #170's to settle.
+
 ## Context and problem statement
 
 The framework was authored around "Claude" — naming ("Claude Code framework",

--- a/docs/adr/0014-work-intake-and-triage-process.md
+++ b/docs/adr/0014-work-intake-and-triage-process.md
@@ -76,6 +76,15 @@ behind it.
 straight to realisation — the pipeline binds *net-new features, structural
 changes, and external contributions*, not trivial hygiene.
 
+> **Amended 2026-08-22 — the incident lane.** A fix for a defect already
+> affecting users is a structural change, so phases 1, 2, 4 and 5 bind it as
+> written. **Phase 3 does not:** ranking against current work has no meaning for
+> something being done because production is broken, and the pipeline had no
+> lane for it. The trace is deferred, not waived — the delivering pull request
+> carries the roadmap entry. Recorded because #171 reached delivery without it
+> and nothing was wrong: an exemption that is never written down is
+> indistinguishable from an omission, and gets repeated.
+
 ### Consequences
 
 - Good: scope stops leaking (closing integrity); duplicates are caught before

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -147,6 +147,9 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - Replace `echo | docker login` with `docker/login-action` (DockerHub + GHCR) *(#100, closes #60)*
 - Implement full tag strategy: `latest`, `edge`, `vX.Y.Z`, `vX.Y`, fully-pinned `vX.Y.Z_tf-A.B.C_aws-D.E.F` *(#100)*
 - Enable Docker Scout CVE monitoring *(#100)*
+- Assert the published tag set by digest, and keep the registry's immutability
+  rules in step with the publication matrix — the floating `vX.Y` was immutable
+  at the registry, so `v10.0.1` published half its tags *(#171)*
 
 ### Phase 4 — CI/CD hardening & code quality *(P1)* — folds in #103, #104
 - Add `pull_request` trigger to `lint-dockerfile` and `build-test` — ADR-0013 *(#103, closes #46)*

--- a/docs/work-intake-and-triage.md
+++ b/docs/work-intake-and-triage.md
@@ -4,7 +4,8 @@ Operational checklist for the five-phase intake pipeline decided in
 [ADR-0014](adr/0014-work-intake-and-triage-process.md). The *why* and the phase
 definitions live there; this file is the *how*. It binds net-new features,
 structural changes, and external contributions — trivial hygiene (typos, pure
-version bumps, one-line fixes) skips to phase 5.
+version bumps, one-line fixes) skips to phase 5, and an incident fix skips
+phase 3 alone.
 
 ## The pipeline
 
@@ -27,6 +28,11 @@ version bumps, one-line fixes) skips to phase 5.
 - [ ] `go` → create the issue: it is the **qualified spec** and its single home.
 
 ### 3. Prioritisation
+
+> **Incident lane** — a fix for a defect already affecting users skips this
+> phase: there is no ranking to arbitrate. The delivering pull request carries
+> the roadmap entry instead.
+
 - [ ] Rank against current work (phase/priority in `docs/roadmap.md`).
 - [ ] Identify dependencies and blockers; link them.
 - [ ] Add to the roadmap (phase line; Decisions table when a decision is taken).


### PR DESCRIPTION
## Summary

Two decisions from one finding, both taken by the maintainer on 2026-08-22.

### The incident lane

ADR-0014 binds *net-new features, structural changes, and external
contributions*, and exempts only *"a typo, a pure version bump, or an obvious
one-line fix"*. An incident fix is a structural change, so the pipeline applies
— **including phase 3**, whose stated purpose is ranking against current work.

That ranking has no meaning for something being done because production is
broken. #171 went from `go` to delivered inside an hour and never reached
`docs/roadmap.md`. Nothing was done wrong: the process had nowhere to put it.

Phase 3 is now skipped for an incident, **and only phase 3** — phases 1, 2, 4
and 5 bind as before. The trace is **deferred, not waived**: the delivering pull
request carries the roadmap entry, so the exemption cannot quietly become a
hole.

Written as a **dated amendment** rather than a new ADR: the decision ADR-0014
records — five phases, human go/nogo, closing integrity — is unchanged, and this
extends the scale-down mechanism that already exists for hygiene. A new ADR
would split the intake decision across two documents (conventions L2). Say so at
review if you read it as a change of decision rather than a clarification, and
it becomes a supersede instead.

### Why it was missed at all

`CLAUDE.md` imported `AGENTS.md`, `docs/conventions.md` and
`docs/adr/README.md`. The intake checklist was **linked from `AGENTS.md`, not
loaded** — so an agent knows it exists and never has its phases in front of it.
Two sessions then skipped the same phase (#170's qualification, #171).

This is the exact failure ADR-0009's 2026-07-23 amendment already recorded for
the conventions: *"A link had proven insufficient (an agent skipped it and fell
back on generic defaults)."* Same cause, same outcome, a second time.

`docs/work-intake-and-triage.md` joins the imports, and ADR-0009 says so —
marked as an **immediate measure, not a criterion**: what an agent must hold in
context is #170's question, and adding a fourth import here does not pre-empt
its answer.

### The roadmap entry for #171

The new lane says the delivering pull request carries it. That was #172, which
**merged before this rule existed**, so the entry has no delivering PR left to
ride. It is folded in here — the rule and its first application in one place —
as a Phase 3 line, next to the tag-strategy item it makes verifiable.

## What is not here

- **The criterion** for context loading stays with #170.
- **The `health-check` charter** that would have caught the missing entry
  mechanically is recorded in #106 for Phase 7. Three of the four gaps found in
  that audit are machine-detectable; whether a qualified issue reached the
  roadmap *when it should have* is the fourth, and it depends on this PR.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (ADR-0014 and ADR-0009,
      both **amended in place**, dated)
- [ ] This PR is **not** a structural change — no ADR needed

Neither file is on `adr-check`'s structural paths, so the gate is not asking for
this; both amendments are here because the documents would otherwise stop being
true — ADR-0009's amendment enumerates the imports, and there is now a fourth.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

`./scripts/validate.sh --fast` green, including the ADR-files ↔ index check.
Branched from `master`, independent of #176.