### PR TITLE
ci(publish): serialise the publishing workflows

### DIFF
--- a/.github/workflows/dockerhub-description-update.yml
+++ b/.github/workflows/dockerhub-description-update.yml
@@ -9,6 +9,13 @@ on:
     paths:
       - README.md
       - .github/workflows/dockerhub-description-update.yml
+
+# The description is a republish of the current README, so a superseded run has
+# nothing left to contribute.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dockerHubDescription:
     runs-on: ubuntu-22.04

--- a/.github/workflows/push-edge.yml
+++ b/.github/workflows/push-edge.yml
@@ -17,6 +17,12 @@ on:
       - "supported_versions.json"
       - "tests/**"
 
+# `edge` is a republish of the current state of master, so a superseded run has
+# nothing left to contribute. The release publisher queues instead (ADR-0018).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_push_edge:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,6 +26,15 @@ permissions:
   pull-requests: write
   issues: write
 
+# Serialise the publishing runs: two merges landing close together would
+# otherwise race, and the run that finishes last wins rather than the commit
+# that landed last. Unlike the other publishers this one queues instead of
+# cancelling: a run interrupted between the GitHub release and the image pushes
+# leaves the half-published state of #171 (ADR-0018).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,11 +26,8 @@ permissions:
   pull-requests: write
   issues: write
 
-# Serialise the publishing runs: two merges landing close together would
-# otherwise race, and the run that finishes last wins rather than the commit
-# that landed last. Unlike the other publishers this one queues instead of
-# cancelling: a run interrupted between the GitHub release and the image pushes
-# leaves the half-published state of #171 (ADR-0018).
+# Queues instead of cancelling, unlike the other publishers: a run interrupted
+# between the GitHub release and the image pushes half-publishes (ADR-0018).
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false

--- a/docs/adr/0018-single-owner-publication-matrix.md
+++ b/docs/adr/0018-single-owner-publication-matrix.md
@@ -76,6 +76,16 @@ Chosen option: **one publisher per tag**. The published set:
 > it asserted that each tag existed, not what it resolved to; it now compares
 > digests and asserts the registry's rules against the table above (#171).
 
+> **Amended 2026-08-23** — one publisher per tag also means one publishing run
+> at a time: a workflow that overlaps itself is the two-writer race with a
+> single name on it, and the winner is the run that finishes last rather than
+> the commit that landed last. Each publisher therefore declares a
+> `concurrency` group, and the cancel policy follows what the run owns:
+> `push-edge` and `dockerhub-description-update` republish the current state of
+> `master`, so a superseded run is cancelled; `release-please` queues, because
+> cancelling it between the GitHub release and the image pushes produces the
+> half-published state above (#173).
+
 ### Consequences
 
 - Good: `latest` has one writer, so its content is defined at all times. The

--- a/docs/adr/0018-single-owner-publication-matrix.md
+++ b/docs/adr/0018-single-owner-publication-matrix.md
@@ -77,14 +77,11 @@ Chosen option: **one publisher per tag**. The published set:
 > digests and asserts the registry's rules against the table above (#171).
 
 > **Amended 2026-08-23** — one publisher per tag also means one publishing run
-> at a time: a workflow that overlaps itself is the two-writer race with a
-> single name on it, and the winner is the run that finishes last rather than
-> the commit that landed last. Each publisher therefore declares a
-> `concurrency` group, and the cancel policy follows what the run owns:
-> `push-edge` and `dockerhub-description-update` republish the current state of
-> `master`, so a superseded run is cancelled; `release-please` queues, because
-> cancelling it between the GitHub release and the image pushes produces the
-> half-published state above (#173).
+> at a time, so each declares a `concurrency` group. The cancel policy follows
+> what the run owns: `push-edge` and `dockerhub-description-update` republish
+> the current state of `master`, so a superseded run is cancelled;
+> `release-please` queues, because cancelling it between the GitHub release and
+> the image pushes leaves the half-published state of #171 (#173).
 
 ### Consequences
 


### PR DESCRIPTION
## Summary

**Hygiene, not an integrity fix.** The first version of this description
oversold it, and the record should be straight: this failure has never been
observed, and it is delivered because it is cheap and makes the eight workflows
uniform, not because anything is broken.

The three workflows that publish declared no `concurrency` group, so two merges
landing on `master` close together start two runs of the same workflow. Only
one of the three blocks changes behaviour in a way that matters:

| Workflow | Policy | What it buys |
|---|---|---|
| `push-edge` | `cancel-in-progress: true` | runner time on rapid pushes, and uniformity with the five pull-request workflows. Worst case avoided: `edge` serves the older of two merges until the next push — on a tag whose contract is "the tip of `master`, no guarantees" |
| `dockerhub-description-update` | `cancel-in-progress: true` | same, for the README |
| `release-please` | `cancel-in-progress: false` | the real change: with no block GitHub runs both **in parallel**, not queued. This serialises them |

Honest bounds on the last one: the dangerous case needs two releases created
inside one publication window, and release-please maintains one Release PR at a
time. The cost is not nil either — every push to `master` now queues behind a
running publication (~20 min of multi-arch builds), delaying the Release-PR
refresh.

**What this is not.** It is not the answer to #171. That was a publication
defect nothing asserted, and what closes that class is assertion
(`validate.sh --published`, #172), not serialisation. Publication still runs no
assertion about the image itself — the real gap, tracked separately.

Roadmap phase / closes: Phase 4 — closes #173

## Breaking change

None.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: [ADR-0018](../blob/master/docs/adr/0018-single-owner-publication-matrix.md), dated amendment 2026-08-23)
- [ ] This PR is **not** a structural change — no ADR needed

Amended rather than superseded: one publisher per tag is unchanged, and this
records that it also means one publishing run at a time.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

## Verification

`./scripts/validate.sh --fast` green; all eight workflows re-parsed as YAML and
their `concurrency` blocks read back, confirming the two policies land on the
right workflows.

Second commit, after review: the amendment's trailing `(#173)` sat against "the
half-published state above" and read as if #173 were that state — it is #171.
Both are now named where they belong, and the amendment drops the restatement
of the two-writer race this ADR's own decision drivers already carry.