### PR TITLE
docs(roadmap): drop dead references and correct the inert role mapping

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -6,7 +6,7 @@ what Claude Code reads by name.
 
 | Path | Purpose |
 |---|---|
-| `settings.json` | SessionStart hook wiring (→ `scripts/agent-session-start.sh`), the role→model mapping (ADR-0006), and a verify-workflow permission allow-list. |
+| `settings.json` | SessionStart hook wiring (→ `scripts/agent-session-start.sh`), a verify-workflow permission allow-list, and a role→model mapping nothing reads yet (#152). |
 | `settings.local.json` | Personal overrides. **Git-ignored** — never committed. |
 
 The bootstrap the hook runs lives in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,10 @@ One home per fact: reference these, never copy them.
 - **Roles (ADR-0006):** `orchestrator` (planning, diff review before push, ADR
   drafting), `executor` (scoped implementation), `reviewer` (diff/lint/security
   passes). Executor output is diff-reviewed by the orchestrator before push.
-  The role→model mapping lives only in `.claude/settings.json`. Phase briefs are
-  ephemeral (conversation only) — reconstructable from the roadmap + ADRs.
+  The role→model mapping is declared in `.claude/settings.json`, but nothing
+  reads it yet (#152): the roles bind as a discipline, not as a mechanism.
+  Phase briefs are ephemeral (conversation only) — reconstructable from the
+  roadmap + ADRs.
 - **Session commits end with the session trailer** — the git trailers appended
   to the commit body identifying the agent and linking the session (e.g.
   `Co-Authored-By: …` + the session URL). Traceability: commit → session.

--- a/docs/adr/0018-single-owner-publication-matrix.md
+++ b/docs/adr/0018-single-owner-publication-matrix.md
@@ -90,7 +90,8 @@ Chosen option: **one publisher per tag**. The published set:
   pushes), which is build cache reuse rather than new builds.
 - Follow-ups: a check asserting that each declared tag has exactly one
   publisher belongs to the verification oracle (ADR-0016) and is tracked in
-  #152; GHCR as a second registry stays with epic #100.
+  #152; GHCR as a second registry stays with roadmap Phase 3 (epic #100, closed
+  2026-08-23 with its tasks re-homed there).
 
 ## More information
 

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -15,14 +15,15 @@ AGENTS.md ─────────────► agent entry point + session
 CLAUDE.md ─────────────► thin Claude Code adapter — imports AGENTS.md,
   │                       docs/conventions.md and docs/adr/README.md into the
   │                       session context at start (ADR-0009, amended)
-  └─ .claude/{settings.json, README.md}   hook wiring + role→model map + perms
+  └─ .claude/{settings.json, README.md}   hook wiring + perms
 
 scripts/agent-session-start.sh ► agnostic bootstrap (reused by the adapter)
 ```
 
-Work is organised by **role** (`orchestrator`/`executor`/`reviewer`, ADR-0006);
-the model per role lives only in `.claude/settings.json`. Another agent adds its
-own adapter and reuses the core unchanged.
+Work is organised by **role** (`orchestrator`/`executor`/`reviewer`, ADR-0006).
+The model per role is declared in `.claude/settings.json` and no mechanism reads
+it; wiring it is #152. Another agent adds its own adapter and reuses the core
+unchanged.
 
 ## The local verify harness
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,7 +127,7 @@ Agnostic core + a thin Claude Code adapter (ADR-0009).
 - `AGENTS.md` at repo root — agnostic SSOT (sources of truth, ADR rule, no hard-coded values); thin `CLAUDE.md` adapter pointing to it (Claude Code reads `CLAUDE.md`)
 - `docs/agent-framework.md` (architecture, walkthrough, token-cost notes) + `docs/conventions.md` (the working conventions, extracted from this file)
 - `.claude/README.md` (Claude adapter map)
-- `.claude/settings.json` — permissions allowlist **+ the role→model mapping** (`orchestrator`/`executor`/`reviewer`) per ADR-0006; no PostToolUse hook yet
+- `.claude/settings.json` — permissions allowlist + the role→model mapping (`orchestrator`/`executor`/`reviewer`) per ADR-0006, inert until #152 wires it; no PostToolUse hook yet
 - `.gitignore`: `.claude/settings.local.json` *(done early)*
 - `scripts/agent-session-start.sh` (SessionStart hook)
 - Reconcile with Entire-generated `.claude/settings.json` if Entire is activated (ADR-0007 / `docs/entire-setup.md`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ to green; the human owns the merge).
 | ADR enforcement | PR-template checkbox + `adr-check.yml` CI gate + CODEOWNERS (no soft-rule-only) | this doc |
 | Branch naming | `type/topic` (Conventional types); no tool names | ADR-0008 |
 | Agent-agnostic framework | Generic core (agnostic docs + naming, role/tier orchestration); `.claude/` + `CLAUDE.md` are the Claude Code **adapter** layer | ADR-0009 |
-| Agent orchestration | Role/tier abstraction (`orchestrator`/`executor`/`reviewer`), model mapping in `.claude/settings.json` (generic, drift-free) | ADR-0006 |
+| Agent orchestration | Role/tier abstraction (`orchestrator`/`executor`/`reviewer`); the role→model vehicle is not wired — the declared mapping is inert (#152) | ADR-0006 |
 | PR autonomy | Agent opens PRs & drives CI to green; the human owns the merge | ADR-0012 |
 | PR-triggered CI | `pull_request` on secret-free CI only; no secrets in PR-triggered workflows; `pull_request_target` banned | ADR-0013 |
 | Docs SSOT & concision | Docs point to one home, never restate; prose earns its space | `docs/conventions.md` |
@@ -153,11 +153,12 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 
 ### Phase 4 — CI/CD hardening & code quality *(P1)* — folds in #103, #104
 - Add `pull_request` trigger to `lint-dockerfile` and `build-test` — ADR-0013 *(#103, closes #46)*
-- Add `concurrency:` to every workflow (cancel stale runs) *(#103)*
+- Add `concurrency:` to every workflow; the publishers keep their own cancel policy (ADR-0018) *(#103)*
 - Harmonise buildx `cache-from` / `cache-to` across workflows *(#103)*
 - Restrict the multi-arch build (`amd64,arm64` — ADR-0019) to publish workflows only *(#103)*
 - `scripts/validate.sh`: argument parsing, semver validation, correct platform string, `set -euo pipefail` *(#104)*
 - Extend `container-structure-tests.yml.template`: negative tests (non-root user), binaries-in-`PATH` checks *(#104)*
+- Scope the `DL3059` hadolint ignore to the build stages that need it, instead of the repo-wide ignore in `hadolint.yaml` *(#104)*
 
 ### Phase 5 — Supply chain security *(P1)* — folds in #99
 - `aquasecurity/trivy-action` in `build-test.yml` — fail on critical, non-patchable *(#99)*
@@ -165,12 +166,11 @@ Urgent: current versions are frozen at end-2023 and accrue CVEs.
 - SLSA provenance attestation (`--attest=type=provenance,mode=max`) *(#99)*
 - cosign keyless signing (OIDC GitHub Actions) of published images *(#99)*
 - Explicit least-privilege `permissions:` on every job *(#99)*
-- `validate-supported-versions.yml` (matrix check `supported_versions.json` ↔ `security/`)
 
 ### Phase 6 — Agent skills & subagents *(P1)* — Track B
 Skills (auto-discovered via `SKILL.md` descriptions):
 - `bump-terraform-version`, `bump-awscli-version`, `bump-debian-base`
-- `propose-adr`, `validate-supported-versions`
+- `propose-adr`
 - `.githooks/commit-msg` local hook (Docker-based, opt-in; documented in `CONTRIBUTING.md`)
 
 Subagents & slash commands:


### PR DESCRIPTION
## Summary

Declared scope: **align the plan and the agent docs with what the repository
actually does**, where the text is not merely behind but wrong.

Three claims are contradicted by the repository as it stands:

| Claim | Reality |
|---|---|
| Phase 5 `validate-supported-versions.yml`, Phase 6 `validate-supported-versions` skill | the verification oracle has owned that check since ADR-0016 (#160). The workflow was never created and never will be — a dead reference, the failure mode the "no dead references" learning names |
| Decisions table + Phase 2 content + `AGENTS.md` + `docs/agent-framework.md` + `.claude/README.md`: the role→model mapping "lives in `.claude/settings.json` (generic, drift-free)" | `agentRoles` is not a Claude Code settings key and nothing reads it (#152 P3.2). ADR-0006's one-line-config-edit mechanism does not physically exist, so the roles bind as a discipline, not as a mechanism |
| Phase 4 "`concurrency:` to every workflow (cancel stale runs)" | the publishers cannot share one cancel policy: `release-please` must queue (ADR-0018, amended in #179) |

The wording deliberately states the gap and points at #152 rather than
proposing a fix — wiring the role→model vehicle and dropping `agentRoles` is
#152 PR 3's declared payload, not this PR's.

Also re-homes the one live task epic #104 owned that no other document
carried — scoping the repo-wide `DL3059` hadolint ignore — into Phase 4, so
the epic can be closed with its scope delivered or homed (D6). Its `dev.sh`
section needs no home: #160 deleted the file.

**Second commit** — the first pass reached three of the five homes of the
role→model claim. It now covers all five, and re-points one dead reference the
epic closures created the same day: ADR-0018's follow-up sent GHCR to epic
#100, closed on 2026-08-23 with its tasks re-homed to roadmap Phase 3. The
amendment moves the pointer without touching the decision.

Roadmap phase / closes: process — prepares closing #104

## Breaking change

None.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: [ADR-0018](../blob/master/docs/adr/0018-single-owner-publication-matrix.md), follow-up pointer re-homed)
- [ ] This PR is **not** a structural change — no ADR needed

Worth stating plainly, since the gate cannot: the second commit touches
`.claude/README.md`, which `adr-check` counts as structural, and the ADR-0018
edit satisfies the gate. Neither is a policy change — one corrects a sentence
about a mapping, the other re-points a reference to a closed issue. The gate
passing here is the permissive reading already recorded in #106's doctrine, not
a claim that this PR decides anything.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

## Verification

`./scripts/validate.sh --fast` green after each commit (its ADR index ↔ files
check covers the docs touched here). The five homes of the role→model claim
were enumerated by `grep` over the tracked files, not by memory.