### PR TITLE
docs(ssot): give every fact in the tracking issue a durable home

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Entry point for any agent working `terraform-aws-cli`. Claude Code adapter:
 
 ## Sources of truth (read in order)
 
-1. **Tracking issue [#106](https://github.com/bgauduch/terraform-aws-cli/issues/106)** — live status (open PRs/issues, next actions). Its **body is the status SSOT**, edited in place. Keep it current when state changes.
+1. **Tracking issue [#106](https://github.com/bgauduch/terraform-aws-cli/issues/106)** — what is next, and the work in progress GitHub cannot answer for. Its **body is the status SSOT**, edited in place; anything a GitHub query returns is never restated there (ADR-0001). Get the live state from `list_pull_requests` / `list_issues` / `list_branches`.
 2. **[`docs/conventions.md`](docs/conventions.md)** — the working conventions binding every contributor (branching, commits, delivery, ADRs, docs/language).
 3. **[`docs/roadmap.md`](docs/roadmap.md)** — the plan (phases + Decisions table).
 4. **[`docs/adr/`](docs/adr/)** — the decisions and their rationale.

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ ARG TERRAFORM_VERSION
 ARG DEBIAN_VERSION=trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 ARG DEBIAN_FRONTEND=noninteractive
 
+# One RUN per package in the throwaway stages (hadolint DL3059 is ignored
+# repo-wide): only artifacts are COPY-ed out, so merging them shrinks nothing
+# and makes a single pin bump re-run every install. The final stage merges its
+# RUN, because that one ships.
 # Download Terraform binary
 FROM debian:${DEBIAN_VERSION} AS terraform
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![dockerhub-description-update](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml/badge.svg)](https://github.com/bgauduch/terraform-aws-cli/actions/workflows/dockerhub-description-update.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Docker Pulls](https://img.shields.io/docker/pulls/bgauduch/terraform-aws-cli.svg?label=pulls)](https://hub.docker.com/r/bgauduch/terraform-aws-cli/)
+<!-- The legacy zenika pull count is kept on purpose: it is this image's
+     history, and the tags it counts are the ones #137 will migrate. -->
 [![Docker Pulls (legacy zenika)](https://img.shields.io/docker/pulls/zenika/terraform-aws-cli.svg?label=pulls%20%28legacy%20zenika%29&color=inactive)](https://hub.docker.com/r/zenika/terraform-aws-cli/)
 
 # Terraform and AWS CLI Docker image

--- a/docs/adr/0001-adopt-unified-roadmap-and-agent-framework.md
+++ b/docs/adr/0001-adopt-unified-roadmap-and-agent-framework.md
@@ -47,6 +47,28 @@ truth.
 - Follow-ups: #115 closed as duplicate; #116 retains its Phase 0 work; #106
   repointed to `docs/roadmap.md`.
 
+> **Amended 2026-08-23** — the SSOT split says where the durable plan lives; it
+> never said what the tracking issue may hold, and the issue grew a ledger of
+> merged pull requests, closed issues and branches that is retyped in full on
+> every edit. An untouched line then goes stale silently: the open-PR table
+> drifted on 2026-08-18 and three times on 2026-08-22. Two clauses close it:
+>
+> 1. The tracking issue's body holds only work in progress that **has no home
+>    in GitHub itself**. Anything a GitHub or git query returns — open or
+>    closed issues, open or merged pull requests, branches, releases, tags,
+>    ADRs — is **never** restated there.
+> 2. A learning leaves the body when its home exists, not when someone
+>    remembers it. Conventions L4 says a learning is captured transiently then
+>    promoted; promoting **includes removing**.
+>
+> Clause 1 removes the cause rather than the symptom: every session is already
+> required to reconcile against `list_pull_requests` / `list_issues` /
+> `list_branches`, so storing that answer only creates the drift the
+> reconciliation then has to repair. A table that does not exist cannot be
+> stale. The delivery obligation this changes is [conventions
+> D5](../conventions.md#delivery). Clarification of the split, not a reversal
+> (#178).
+
 ## More information
 
 Supersedes the standalone `docs/claude-framework-roadmap.md` from #116 and the

--- a/docs/adr/0002-contribution-and-release-workflow.md
+++ b/docs/adr/0002-contribution-and-release-workflow.md
@@ -77,3 +77,12 @@ Tag strategy is decided separately in ADR-0003.
 > announced breaks without stating them. Enforcement of an existing mechanism;
 > the decision (Conventional Commits, squash-merge, release-please) is
 > unchanged.
+>
+> **Amended 2026-08-23** — a consequence of the Release-PR trigger worth
+> stating, because it cost a major version: the release train carries what is
+> on `master`, and an unmerged pull request is not on `master`. Merging a
+> Release PR while a breaking change is still in review ships the release
+> without it, and that change then needs a major of its own — v9.0.0 and
+> v10.0.0 on 2026-08-03. Sequencing is the author's call, not the tool's:
+> hold the Release PR, or accept the second major. Implementation specific;
+> the decision is unchanged.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,6 +53,11 @@ Copy the template, take the next free number, fill it in, and reference it from
 the [roadmap](../roadmap.md) Decisions table. A planned `propose-adr` skill will
 scaffold this automatically.
 
+**A number is claimed at merge, not at authoring.** Two open pull requests may
+both hold "the next" number; the one that merges second renumbers. Check the
+index on the base branch before pushing a rename, not when the draft is
+written.
+
 ## Amending vs superseding
 
 The **decision** an ADR records is immutable. To change the repository's history

--- a/docs/agent-framework.md
+++ b/docs/agent-framework.md
@@ -47,6 +47,25 @@ CA trusted system-wide) so the checks below need no manual setup.
 > (`--network=host`, `https_proxy`, sources switched to `https://` + the CA
 > bundle) — the proxy only tunnels HTTPS/CONNECT; plain HTTP returns 405.
 
+### What a hosted session cannot do
+
+Facts about the environment, not about the code — they change what a session
+can promise, and none of them is discoverable from the repository:
+
+- **`--full` cannot complete in a hosted agent session.** The egress proxy
+  terminates TLS and the build containers do not trust its CA, so the image
+  build inside `--full` fails on certificate verification. `--fast` and
+  `--published` are unaffected: the first needs no network, the second is
+  network-only and goes through the proxy like any other HTTPS call. A `--full`
+  verdict has to come from real hardware.
+- **A bot-authored pull request does not run CI on its own.** Its workflow runs
+  wait for a maintainer's approval, so a green tick can be absent because
+  nobody clicked, not because something failed.
+- **A session cannot delete a remote ref**, and does not need to: branches
+  merged through the pull-request flow are deleted by the repository setting.
+- **Parallel work uses one designated branch per session**; any further branch
+  it opens follows [B1](conventions.md#branching), like a human's.
+
 ### Stays in CI (authoritative gate)
 
 On a pull request, `build-test` builds and runs `container-structure-test` on

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -53,10 +53,10 @@ Agent-session rules (authorization boundaries, roles) live in
 - **D4 — A PR's title and description track its current content.** When new
   commits change what the PR delivers, update both in the same pass (the
   title's downstream role: C1).
-- **D5 — A state change ships with its status update.** Opening, merging or
-  closing a PR — or completing a tracked task — edits the tracking issue (#106)
-  body in the same gesture; epic/phase checklists are ticked when the
-  delivering PR merges.
+- **D5 — A state change ships with its status update.** Completing a tracked
+  task, or changing what happens next, edits the tracking issue (#106) body in
+  the same gesture. What a GitHub query returns — a PR, its state, the issues
+  it closes — is `NEVER` restated there (ADR-0001, amended).
 - **D6 — Close an issue or epic `completed` only when its declared scope is
   delivered.** Undelivered scope is re-homed to a tracked issue with the
   pointer in place before closing, or the item stays open. See ADR-0014


### PR DESCRIPTION
## Summary

Delivers #178. Declared scope, unchanged from its spec: **give every
ungraduated fact in #106 a durable home, and write the rule that keeps it
out.**

### The rule — ADR-0001, dated amendment

Two clauses, as decided on 2026-08-22:

1. The tracking issue's body holds only work in progress that **has no home in
   GitHub itself**. Anything a GitHub or git query returns is never restated
   there.
2. A learning leaves the body when its home exists, not when someone remembers
   it — promoting includes removing.

It removes the cause rather than the symptom. Every session is already required
to reconcile against `list_pull_requests` / `list_issues` / `list_branches`, so
storing that answer only creates the drift the reconciliation then repairs. A
table that does not exist cannot be stale.

### Two contradictions the spec did not list

Found while writing it, and fixed here because the rule is incoherent
otherwise — a repository cannot hold two binding rules that contradict:

- **conventions D5** required *"opening, merging or closing a PR … edits the
  tracking issue body"* — precisely the ledger clause 1 forbids. Reworded to
  keep the obligation (a state change updates what happens next) without the
  ledger.
- **`AGENTS.md` source of truth #1** described the body as holding *"open
  PRs/issues"*. It now says what the body is for, and where the live state
  actually comes from.

### The re-homing pass (D6 — before anything is deleted)

| Fact | New home | Why there |
|---|---|---|
| A release train carries what is on `master`; an unmerged PR is not on it | ADR-0002 amendment | a decision with a cost — it bought a second major on 2026-08-03 |
| An ADR number is claimed at merge, not at authoring | `docs/adr/README.md` | it already owns the ADR lifecycle |
| `--full` cannot complete in a hosted session · bot-PR runs need approval · sessions cannot delete remote refs · parallel branches follow B1 | `docs/agent-framework.md` | changes what a session can promise, and none is discoverable from the repo |
| Why the throwaway stages keep one `RUN` per package | `Dockerfile`, at the stages concerned | the DL3059 ignore is repo-wide and its reason lived nowhere |
| Why the legacy `zenika` pull badge stays | `README.md`, HTML comment | it reads as an oversight otherwise |

### Order

**The #106 body edit follows this merge, not the other way round.** Deleting
first and re-homing after is what D6 forbids, and it is the failure that
stranded the Renovate custom manager in #20. Once merged I apply the target
structure to the body: six sections become three plus the header, ~28 000 →
under 10 000 characters.

Two doctrine bullets in #178 are deliberately left open for the maintainer and
are **not** touched here: *"a PR head can lag a push"* (keep only if you have
seen it) and *"a green oracle is not the point"* (either it joins ADR-0016's
rationale or it goes).

Roadmap phase / closes: process — closes #178

## Breaking change

None.

## Architecture Decision Record

- [x] This PR adds/updates an ADR under `docs/adr/` (link: [ADR-0001](../blob/master/docs/adr/0001-adopt-unified-roadmap-and-agent-framework.md), dated amendment 2026-08-23; also ADR-0002 and the ADR index)
- [ ] This PR is **not** a structural change — no ADR needed

Amended rather than superseded on both: ADR-0001's SSOT split still holds and
this states what it never said; ADR-0002's release flow is unchanged and this
records a consequence of its Release-PR trigger.

## Checklist

- [x] PR title follows Conventional Commits
- [x] Commits are scoped and reviewable
- [x] Docs / roadmap updated if behaviour or policy changed
- [x] Docs point to their single home (no restated facts); intros/sections earn their space
- [x] Touches only files within the declared phase scope

## Verification

`./scripts/validate.sh --fast` green. The two added code comments carry no em
or en dash (L5), checked by `grep` rather than by eye.

---
_Generated by [Claude Code](https://claude.ai/code/session_011PhaYLhD89TyhrbzuV5NZ6)_